### PR TITLE
[DENG-3090] Fix README for correct 'flow-name' in local inference server command

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,7 +20,7 @@ You can track the training progress on the Outerbounds UI.
 ## Stand up an example inference server
 
 1. From the e2e directory, run `pip install -r requirements.txt`
-2. Try the inference server locally: `serve run forecast:app_builder flow-name=HelloFlowBQ namespace=<MODEL NAMESPACE>` where
+2. Try the inference server locally: `serve run forecast:app_builder flow-name=TrainingFlowBQ namespace=<MODEL NAMESPACE>` where
 `<MODEL NAMESPACE>` is the namespace used to store the model in Metaflow, e.g. `user:aplacitelli@mozilla.com`.
 
 > [!NOTE]


### PR DESCRIPTION
While trying the local inference server command, I discovered the issue with `flow-name` command line argument.

(More details: https://mozilla-hub.atlassian.net/browse/DENG-3090?focusedCommentId=857180)

Replacing 'HelloFlowBQ' with 'TrainingFlowBQ' fixed the issue.