### PR TITLE
DENG-3090: Fixed serve_config.yaml and README for 'flow-name' and 'version' field

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -58,8 +58,7 @@ applications:
   import_path: forecast:app_builder
   args:
     namespace: "user:CHANGEME" # TODO, change this!
-    flow-name: HelloFlowBQ
-    version: 28
+    flow-name: TrainingFlowBQ
   runtime_env:
     pip:
       - outerbounds[gcp]

--- a/e2e/serve_config.yaml
+++ b/e2e/serve_config.yaml
@@ -20,8 +20,7 @@ applications:
   route_prefix: /
   import_path: forecast:app_builder
   args:
-    flow-name: HelloFlowBQ
-    version: 28
+    flow-name: TrainingFlowBQ
   runtime_env:
     pip:
       - outerbounds[gcp]


### PR DESCRIPTION
Fixes the errors (details in [comment1](https://mozilla-hub.atlassian.net/browse/DENG-3090?focusedCommentId=857728) and [comment2](https://mozilla-hub.atlassian.net/browse/DENG-3090?focusedCommentId=857899)) to be able to successfully execute **Step 6** of [standing up inference server](https://github.com/mozilla/mlops-demo/blob/5d978d8f46a9cf49cb2a307b4db4fd40231a25d0/e2e/README.md#stand-up-an-example-inference-server)

README changes:
- Changed 'flow-name' to TrainingFlowBQ
- Removed 'version' field to allow fetching trained model from metaflow's last successful run

serve_config.yaml changes:
- Removed 'version' field to allow fetching trained model from metaflow's last successful run